### PR TITLE
Removed python-docutils from alsa build script

### DIFF
--- a/tools/build-bluez-alsa
+++ b/tools/build-bluez-alsa
@@ -22,9 +22,9 @@ fi
 
 sudo apt-get -y update
 sudo apt-get -y install autoconf
-sudo apt-get -y install build-essential libtool pkg-config python-docutils \
+sudo apt-get -y install build-essential libtool pkg-config libsbc-dev \
                         libasound2-dev libbluetooth-dev libdbus-1-dev \
-                        libglib2.0-dev libsbc-dev
+                        libglib2.0-dev
 
 git clone https://github.com/Arkq/bluez-alsa.git
 cd bluez-alsa


### PR DESCRIPTION
Since python-docutils is not avaible for bullseye i removed it